### PR TITLE
update GitHub actions/checkout to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install shellcheck
       run: sudo apt-get install -y shellcheck
     - name: clone checknr


### PR DESCRIPTION
Based on what happened with [dbg repo from dependabot](https://github.com/lcn2/dbg/pull/41), we recommend updating GitHub Actions/checkout to v5.

# QUESTION

Why did the [dbg repo](https://github.com/lcn2/dbg) have this action applied to it while other repos such as this one (as well as various IOCCC repos) did not?

Is there a way to have GitHub do what happened to [dbg repo from dependabot](https://github.com/lcn2/dbg/pull/41) to repos such as this?

Or perhaps things are already set up and we simply had to wait (maybe about a week?) for this to happen?